### PR TITLE
Add simple FastAPI-based server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # Vquest
-Virtual Questing Game
+
+Vquest is a minimal virtual questing game powered by an AI dungeon master. A main
+instance of the game hosts a room that players can join from their mobile
+devices. Players propose actions for each step in the quest and then vote on the
+submitted options.
+
+## Running the server
+
+Install the dependencies and start the FastAPI server:
+
+```bash
+pip install -r requirements.txt
+uvicorn server:app --reload
+```
+
+Create a room by sending a `POST` request to `/room`. The response contains a
+random room code that players can use to join. Players submit actions via
+`POST /room/{code}/action` and can vote on the submitted actions with
+`POST /room/{code}/vote`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/server.py
+++ b/server.py
@@ -1,0 +1,72 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import random
+import string
+
+app = FastAPI()
+
+# In-memory room storage
+rooms = {}
+
+
+def generate_code(length: int = 5) -> str:
+    """Generate a random room code."""
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
+
+
+class Action(BaseModel):
+    player: str
+    text: str
+
+
+class Vote(BaseModel):
+    player: str
+    choice: int
+
+
+@app.post("/room")
+def create_room():
+    """Create a new room and return its code."""
+    code = generate_code()
+    rooms[code] = {"actions": [], "votes": []}
+    return {"code": code}
+
+
+@app.post("/room/{code}/action")
+def submit_action(code: str, action: Action):
+    """Submit an action proposal for the given room."""
+    if code not in rooms:
+        return {"error": "Invalid room code"}
+    rooms[code]["actions"].append({"player": action.player, "text": action.text})
+    return {"status": "Action received"}
+
+
+@app.get("/room/{code}/actions")
+def list_actions(code: str):
+    """List submitted actions for a room."""
+    if code not in rooms:
+        return {"error": "Invalid room code"}
+    return rooms[code]["actions"]
+
+
+@app.post("/room/{code}/vote")
+def submit_vote(code: str, vote: Vote):
+    """Submit a vote on an action choice."""
+    if code not in rooms:
+        return {"error": "Invalid room code"}
+    if vote.choice < 0 or vote.choice >= len(rooms[code]["actions"]):
+        return {"error": "Invalid choice"}
+    rooms[code]["votes"].append({"player": vote.player, "choice": vote.choice})
+    return {"status": "Vote recorded"}
+
+
+@app.get("/room/{code}/results")
+def vote_results(code: str):
+    """Return vote counts for each action."""
+    if code not in rooms:
+        return {"error": "Invalid room code"}
+    counts = [0] * len(rooms[code]["actions"])
+    for vote in rooms[code]["votes"]:
+        counts[vote["choice"]] += 1
+    return {"counts": counts}
+


### PR DESCRIPTION
## Summary
- add FastAPI server to manage rooms, actions and votes
- document how to run the server
- add requirements and gitignore

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_686c4fafca888321936cb911244c4ff4