### PR TITLE
docs: add tunnel instructions for remote testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,24 @@ uvicorn backend.main:app --reload
 Open `static/player.html` on a phone or browser for the player view and
 `static/dm.html?code=ROOMCODE` on a large display for the DM screen. The pages
 communicate with the server using WebSockets.
+
+## Remote testing over the internet
+
+During development you may want teammates to try the game from their own
+devices. Expose your local server with a tunneling service and share the public
+URL it provides.
+
+1. Start the FastAPI server as shown above.
+2. In another terminal, run a tunnel to port `8000`. For example:
+
+   ```bash
+   # Cloudflare tunnel (no account required)
+   cloudflared tunnel --url http://localhost:8000
+
+   # or using ngrok
+   ngrok http 8000
+   ```
+
+3. The command prints a public HTTPS address. Give that URL to testers so they
+   can connect to your running instance.
+4. Press `Ctrl+C` in the tunnel process when testing is complete.


### PR DESCRIPTION
## Goal
Explain how to expose the FastAPI server to the internet for remote testers.

## Approach
Documented using Cloudflare tunnel or ngrok to share the local port during development.

## Alternatives
Could set up dedicated hosting or CI integration.

## Risks
Tunnel services can fail or require extra installation; public URL exposes dev server.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8d282d3f08321854151610700e69c