### PR TITLE
Add Render deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,19 @@ communicate with the server using WebSockets.
 
    **Render (free hosting)**
 
+   This repository includes a `render.yaml` configuration for one-click deploys.
+
    1. Push this repository to a public GitHub repo.
-   2. Create a new web service on [Render](https://render.com) using your repo.
-   3. Set the start command to `uvicorn backend.main:app --host 0.0.0.0 --port $PORT`.
-   4. Ensure a `PORT` environment variable is defined (Render sets it automatically).
-   5. Render deploys the app and provides a public URL to share.
+   2. Create a new web service on [Render](https://render.com) and choose
+      "Deploy from repository".
+   3. Render reads `render.yaml`, installs dependencies, and starts the app
+      with `uvicorn backend.main:app --host 0.0.0.0 --port $PORT`.
+   4. Render sets the `PORT` environment variable automatically and provides a
+      public URL to share.
 
 ### Troubleshooting
 
 - If the tunnel command fails, ensure port `8000` is reachable and not blocked.
-- If the Render service doesn't start, verify that requirements are installed,
-  the start command matches the example above, and the app is binding to
-  `0.0.0.0` on the `PORT` environment variable.
+- If the Render service doesn't start, ensure `render.yaml` is present,
+  dependencies installed, and the app is binding to `0.0.0.0` on the `PORT`
+  environment variable.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,14 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.staticfiles import StaticFiles
 from typing import Dict, List
+import os
+from pathlib import Path
 
 from . import rooms, models
 
 app = FastAPI()
-app.mount("/", StaticFiles(directory="static", html=True), name="static")
+static_dir = Path(__file__).resolve().parent.parent / "static"
+app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
 
 
 class ConnectionManager:
@@ -72,3 +75,10 @@ async def room_ws(code: str, websocket: WebSocket) -> None:
             await manager.broadcast(code, {"message": data})
     except WebSocketDisconnect:
         manager.disconnect(code, websocket)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("PORT", 8000))
+    uvicorn.run("backend.main:app", host="0.0.0.0", port=port)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: vquest
+    env: python
+    buildCommand: "pip install -r requirements.txt"
+    startCommand: "uvicorn backend.main:app --host 0.0.0.0 --port $PORT"


### PR DESCRIPTION
## Goal
Improve deployment experience by treating Render as the default hosting target.

## Approach
- Add `render.yaml` with build and start commands for Render.
- Load static assets via `pathlib` and start the FastAPI app from `backend/main.py` using the `PORT` env variable.
- Document Render one-click deployment and troubleshooting steps in README.

## Alternatives
- Use a Procfile instead of `render.yaml`.
- Keep deployment instructions only in README without automated config.

## Risks
- Misconfigured `render.yaml` could prevent deployment if Render's schema changes.

## Testing
- `pytest`
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8f9472c2483219adf310922ddc333