### PR TITLE
feat: Implement game world creation feature

### DIFF
--- a/static/dm.html
+++ b/static/dm.html
@@ -12,19 +12,19 @@
   <div id="root" style="max-width: 500px; margin: 2em auto; background: #fffbe6cc; border-radius: 16px; box-shadow: 2px 2px 12px #0003; padding: 2em;"></div>
   <script>
 
-    // Quest management
-    const QUESTS_KEY = 'vquest_quests';
-    function getQuests() {
-      const raw = localStorage.getItem(QUESTS_KEY);
+    // World management
+    const WORLDS_KEY = 'vquest_worlds';
+    function getWorlds() {
+      const raw = localStorage.getItem(WORLDS_KEY);
       if (raw) return JSON.parse(raw);
-      // Default quests
+      // Default worlds
       return [
-        { name: 'Dragon Hunt', context: 'A dragon has been terrorizing the kingdom. The party must track it to its lair and defeat it.' },
-        { name: 'Lost Artifact', context: 'A legendary artifact has gone missing from the royal vault. The party must recover it before it falls into the wrong hands.' },
-        { name: 'Haunted Forest', context: 'Villagers report strange happenings in the nearby forest. The party must investigate and lift the curse.' }
+        { name: 'Dragon\'s Peak', description: 'A dragon has been terrorizing the kingdom. The party must track it to its lair and defeat it.' },
+        { name: 'The Sunken City', description: 'A legendary artifact has gone missing from the royal vault. The party must recover it before it falls into the wrong hands.' },
+        { name: 'Whispering Woods', description: 'Villagers report strange happenings in the nearby forest. The party must investigate and lift the curse.' }
       ];
     }
-    function saveQuests(qs) { localStorage.setItem(QUESTS_KEY, JSON.stringify(qs)); }
+    function saveWorlds(ws) { localStorage.setItem(WORLDS_KEY, JSON.stringify(ws)); }
 
     // AI settings management
     const AI_SETTINGS_KEY = 'vquest_ai_settings';
@@ -38,11 +38,11 @@
 
     function App() {
       const [roomCode, setRoomCode] = React.useState(null);
-      const [quests, setQuests] = React.useState(getQuests());
+      const [worlds, setWorlds] = React.useState(getWorlds());
       const [aiSettings, setAiSettings] = React.useState(getAiSettings());
-      const [selectedQuest, setSelectedQuest] = React.useState(quests[0]?.name || '');
+      const [selectedWorld, setSelectedWorld] = React.useState(worlds[0]?.name || '');
       const [showSettings, setShowSettings] = React.useState(false);
-      const [editQuest, setEditQuest] = React.useState(null);
+      const [editWorld, setEditWorld] = React.useState(null);
       const wsRef = React.useRef(null);
 
       const [context, setContext] = React.useState('');
@@ -52,23 +52,38 @@
       const [players, setPlayers] = React.useState({});
       const [phase, setPhase] = React.useState('SUBMITTING');
       const [winningAction, setWinningAction] = React.useState(null);
+      const [worldImage, setWorldImage] = React.useState(null);
 
-      // Create room with selected quest context
+      // Create room with selected world description
       const createRoom = async () => {
-        const questObj = quests.find(q => q.name === selectedQuest);
+        const worldObj = worlds.find(w => w.name === selectedWorld);
         const res = await fetch('/room', {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
           body: JSON.stringify({
-            context: questObj?.context || '',
-            prompt: questObj?.prompt || 'The adventure begins! What will you do first?',
+            world: worldObj,
+            prompt: worldObj?.prompt || 'The adventure begins! What will you do first?',
             ai_settings: aiSettings
           })
         });
         const data = await res.json();
         setRoomCode(data.code);
-        setContext(questObj?.context || '');
-        setPrompt(questObj?.prompt || 'The adventure begins! What will you do first?');
+        setContext(worldObj?.description || '');
+        setPrompt(worldObj?.prompt || 'The adventure begins! What will you do first?');
+      };
+
+      const generateImage = async () => {
+        const worldObj = worlds.find(w => w.name === selectedWorld);
+        const res = await fetch('/world/image', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            description: worldObj?.description || '',
+            artStyle: worldObj?.artStyle || ''
+          })
+        });
+        const data = await res.json();
+        setWorldImage(data.imageUrl);
       };
 
       const nextStep = async () => {
@@ -120,66 +135,68 @@
 
       // Settings modal logic
       function openSettings() {
-        setEditQuest(null);
+        setEditWorld(null);
         setShowSettings(true);
       }
       function closeSettings() { setShowSettings(false); }
-      function startEdit(q) { setEditQuest(q); setShowSettings(true); }
-      function saveQuest(q) {
-        let newQuests = quests.slice();
-        if (editQuest) {
-          newQuests = newQuests.map(x => x.name === editQuest.name ? q : x);
+      function startEdit(w) { setEditWorld(w); setShowSettings(true); }
+      function saveWorld(w) {
+        let newWorlds = worlds.slice();
+        if (editWorld) {
+          newWorlds = newWorlds.map(x => x.name === editWorld.name ? w : x);
         } else {
-          newQuests.push(q);
+          newWorlds.push(w);
         }
-        setQuests(newQuests);
-        saveQuests(newQuests);
-        setEditQuest(null);
+        setWorlds(newWorlds);
+        saveWorlds(newWorlds);
+        setEditWorld(null);
         setShowSettings(false);
       }
       function handleAiSettingsChange(newSettings) {
         setAiSettings(newSettings);
         saveAiSettings(newSettings);
       }
-      function deleteQuest(q) {
-        const newQuests = quests.filter(x => x.name !== q.name);
-        setQuests(newQuests);
-        saveQuests(newQuests);
-        setEditQuest(null);
+      function deleteWorld(w) {
+        const newWorlds = worlds.filter(x => x.name !== w.name);
+        setWorlds(newWorlds);
+        saveWorlds(newWorlds);
+        setEditWorld(null);
         setShowSettings(false);
-        if (selectedQuest === q.name && newQuests.length) setSelectedQuest(newQuests[0].name);
+        if (selectedWorld === w.name && newWorlds.length) setSelectedWorld(newWorlds[0].name);
       }
 
-      // Quest context for current selection
-      const questObj = quests.find(q => q.name === selectedQuest);
+      // World description for current selection
+      const worldObj = worlds.find(w => w.name === selectedWorld);
 
       return React.createElement('div', null,
         React.createElement('h1', null, 'DM Screen'),
         showSettings
           ? React.createElement(SettingsModal, {
-              quests, editQuest, aiSettings,
+              worlds, editWorld, aiSettings,
               onClose: closeSettings,
               onEdit: startEdit,
-              onSave: saveQuest,
-              onDelete: deleteQuest,
+              onSave: saveWorld,
+              onDelete: deleteWorld,
               onAiSettingsChange: handleAiSettingsChange
             })
           : !roomCode
             ? React.createElement('div', null,
                 React.createElement('div', {style: {marginBottom: '1em'}},
-                  React.createElement('label', {htmlFor: 'questSel', style: {fontWeight: 'bold'}}, 'Quest: '),
+                  React.createElement('label', {htmlFor: 'worldSel', style: {fontWeight: 'bold'}}, 'World: '),
                   React.createElement('select', {
-                    id: 'questSel', value: selectedQuest,
-                    onChange: e => setSelectedQuest(e.target.value),
+                    id: 'worldSel', value: selectedWorld,
+                    onChange: e => setSelectedWorld(e.target.value),
                     style: {fontSize: '1em', marginRight: '1em'}
                   },
-                    quests.map(q => React.createElement('option', {key: q.name, value: q.name}, q.name))
+                    worlds.map(w => React.createElement('option', {key: w.name, value: w.name}, w.name))
                   ),
                   React.createElement('button', {onClick: openSettings, style: {float: 'right'}}, '⚙️ Settings')
                 ),
-                questObj && React.createElement('div', {style: {marginBottom: '1em', fontStyle: 'italic', background: '#f4e1b6', padding: '0.7em', borderRadius: '8px'}}, questObj.context),
-                React.createElement('div', {style: {marginTop: '2em', textAlign: 'center'}},
-                  React.createElement('button', {onClick: createRoom, style: {fontSize: '1.2em', padding: '0.7em 2em'}}, 'Create Room')
+                worldObj && React.createElement('div', {style: {marginBottom: '1em', fontStyle: 'italic', background: '#f4e1b6', padding: '0.7em', borderRadius: '8px'}}, worldObj.description),
+                worldImage && React.createElement('img', {src: worldImage, style: {maxWidth: '100%', borderRadius: '8px'}}),
+                React.createElement('div', {style: {marginTop: '1em', textAlign: 'center'}},
+                  React.createElement('button', {onClick: generateImage, style: {fontSize: '1em', padding: '0.5em 1em', marginRight: '1em'}}, 'Generate Image'),
+                  React.createElement('button', {onClick: createRoom, style: {fontSize: '1.2em', padding: '0.7em 2em'}}, 'Create Game World')
                 )
               )
             : React.createElement('div', null,
@@ -224,11 +241,25 @@
     }
 
     // Settings modal component
-    function SettingsModal({quests, editQuest, aiSettings, onClose, onEdit, onSave, onDelete, onAiSettingsChange}) {
-      const [name, setName] = React.useState(editQuest ? editQuest.name : '');
-      const [context, setContext] = React.useState(editQuest ? editQuest.context : '');
+    function SettingsModal({worlds, editWorld, aiSettings, onClose, onEdit, onSave, onDelete, onAiSettingsChange}) {
+      const [name, setName] = React.useState(editWorld ? editWorld.name : '');
+      const [description, setDescription] = React.useState(editWorld ? editWorld.description : '');
+      const [genre, setGenre] = React.useState(editWorld ? editWorld.genre : '');
+      const [artStyle, setArtStyle] = React.useState(editWorld ? editWorld.artStyle : '');
+      const [gameMechanics, setGameMechanics] = React.useState(editWorld ? editWorld.gameMechanics : '');
+      const [winLossConditions, setWinLossConditions] = React.useState(editWorld ? editWorld.winLossConditions : '');
       const [provider, setProvider] = React.useState(aiSettings.provider);
       const [apiKey, setApiKey] = React.useState(aiSettings.apiKey);
+
+      async function handleAutoComplete() {
+        const res = await fetch('/world/autocomplete', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({ description })
+        });
+        const data = await res.json();
+        setDescription(data.description);
+      }
 
       function handleSaveAi() {
         onAiSettingsChange({ provider, apiKey });
@@ -272,7 +303,7 @@
 
           React.createElement('hr'),
 
-          React.createElement('h2', null, editQuest ? 'Edit Quest' : 'Add Quest'),
+          React.createElement('h2', null, editWorld ? 'Edit World' : 'Add World'),
           React.createElement('div', null,
             React.createElement('label', null, 'Name: '),
             React.createElement('input', {
@@ -281,33 +312,67 @@
             })
           ),
           React.createElement('div', null,
-            React.createElement('label', null, 'Context: '),
+            React.createElement('label', null, 'Description: '),
             React.createElement('textarea', {
-              value: context, onChange: e => setContext(e.target.value),
+              value: description, onChange: e => setDescription(e.target.value),
               rows: 3, style: {width: '90%', fontFamily: 'inherit', fontSize: '1em'}
-            })
+            }),
+            React.createElement('button', {onClick: handleAutoComplete, style: {marginLeft: '1em'}}, 'Auto-complete')
           ),
+
+          React.createElement('details', null,
+            React.createElement('summary', null, 'Advanced Options'),
+            React.createElement('div', null,
+              React.createElement('label', null, 'Genre: '),
+              React.createElement('input', {
+                value: genre, onChange: e => setGenre(e.target.value),
+                style: {width: '90%'}
+              })
+            ),
+            React.createElement('div', null,
+              React.createElement('label', null, 'Art Style: '),
+              React.createElement('input', {
+                value: artStyle, onChange: e => setArtStyle(e.target.value),
+                style: {width: '90%'}
+              })
+            ),
+            React.createElement('div', null,
+              React.createElement('label', null, 'Game Mechanics: '),
+              React.createElement('textarea', {
+                value: gameMechanics, onChange: e => setGameMechanics(e.target.value),
+                rows: 3, style: {width: '90%', fontFamily: 'inherit', fontSize: '1em'}
+              })
+            ),
+            React.createElement('div', null,
+              React.createElement('label', null, 'Win/Loss Conditions: '),
+              React.createElement('textarea', {
+                value: winLossConditions, onChange: e => setWinLossConditions(e.target.value),
+                rows: 3, style: {width: '90%', fontFamily: 'inherit', fontSize: '1em'}
+              })
+            )
+          ),
+
           React.createElement('div', {style: {marginTop: '1em'}},
             React.createElement('button', {
-              onClick: () => name && context && onSave({name, context}),
+              onClick: () => name && description && onSave({name, description, genre, artStyle, gameMechanics, winLossConditions}),
               style: {marginRight: '1em'}
-            }, 'Save Quest'),
-            editQuest && React.createElement('button', {
-              onClick: () => onDelete({name, context}),
+            }, 'Save World'),
+            editWorld && React.createElement('button', {
+              onClick: () => onDelete({name, description}),
               style: {marginRight: '1em', background: '#c44'}
             }, 'Delete'),
             React.createElement('button', {onClick: onClose}, 'Cancel')
           ),
           React.createElement('hr'),
-          React.createElement('h3', null, 'All Quests'),
-          ...quests.map(q => [
+          React.createElement('h3', null, 'All Worlds'),
+          ...worlds.map(w => [
             React.createElement('div', {
-              key: q.name,
+              key: w.name,
               style: {margin: '0.5em 0', padding: '0.5em', background: '#f4e1b6', borderRadius: '8px'}
             },
-              React.createElement('b', null, q.name),
-              React.createElement('span', {style: {marginLeft: '1em'}}, q.context.slice(0, 40) + (q.context.length > 40 ? '...' : '')),
-              React.createElement('button', {onClick: () => onEdit(q), style: {float: 'right'}}, 'Edit')
+              React.createElement('b', null, w.name),
+              React.createElement('span', {style: {marginLeft: '1em'}}, w.description.slice(0, 40) + (w.description.length > 40 ? '...' : '')),
+              React.createElement('button', {onClick: () => onEdit(w), style: {float: 'right'}}, 'Edit')
             )
           ])
         )


### PR DESCRIPTION
This feature allows players to create their own game worlds with detailed settings.

- Renamed 'Quests' to 'Game Worlds' for clarity.
- Expanded the world creation form to include fields for genre, art style, game mechanics, and win/loss conditions.
- Added an 'Auto-complete' feature to help users expand on their world descriptions.
- Implemented a 'World Image Generation' feature to create a visual representation of the world.
- Updated the backend to support the new world creation flow and provide more context to the AI story generator.