### PR TITLE
Fix: Remove response_format from AI call

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -229,8 +229,7 @@ async function generate_world_details(world, ai_settings) {
     model,
     messages: [{ role: "user", content: prompt }],
     temperature: 0.7,
-    max_tokens: 500,
-    response_format: { "type": "json_object" }
+    max_tokens: 500
   };
 
   switch (provider) {


### PR DESCRIPTION
This commit removes the `response_format` parameter from the call to the AI service in the `generate_world_details` function. This parameter was causing a 400 Bad Request error with some AI providers. The prompt already instructs the model to return JSON, so this parameter is not strictly necessary. This change makes the feature more robust and compatible with different AI providers.