### PR TITLE
Fix: Add frontend error handling for image generation

### DIFF
--- a/static/dm.html
+++ b/static/dm.html
@@ -82,6 +82,11 @@
             artStyle: worldObj?.artStyle || ''
           })
         });
+        if (!res.ok) {
+          const err = await res.json();
+          alert(`Error generating image: ${err.detail || 'Unknown error'}`);
+          return;
+        }
         const data = await res.json();
         setWorldImage(data.imageUrl);
       };


### PR DESCRIPTION
This commit adds error handling to the frontend for the image generation feature. The `generateImage` function in `static/dm.html` now checks if the fetch request was successful. If not, it parses the error details from the response and displays them in an alert to the user.

This ensures that the user receives clear feedback if the image generation fails, for reasons such as a missing or invalid API key.