### PR TITLE
Fix: Add explicit node-fetch import to src/app.js

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const http = require('http');
 const path = require('path');
 const { WebSocketServer } = require('ws');
+const fetch = require('node-fetch');
 
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
This commit fixes a server crash issue on Render that was causing the application to get stuck in a restart loop.

The crash was caused by `src/app.js` using the `fetch` function without explicitly importing `node-fetch`. This works in Node.js environments where `fetch` is available globally, but fails in older environments where it is not.

This commit adds `const fetch = require('node-fetch');` to the top of `src/app.js` to ensure that the application can run in a wider range of Node.js environments, including the one used by Render.